### PR TITLE
Add jupyter

### DIFF
--- a/dockerfiles/Dockerfile.cpu
+++ b/dockerfiles/Dockerfile.cpu
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM tensorflow/tensorflow:latest-py3
+FROM tensorflow/tensorflow:latest-py3-jupyter
 
 # File Author / Maintainer
 MAINTAINER Garrett Hoffman

--- a/dockerfiles/Dockerfile.gpu
+++ b/dockerfiles/Dockerfile.gpu
@@ -1,6 +1,6 @@
 
 # Set the base image to Ubuntu
-FROM tensorflow/tensorflow:latest-gpu-py3
+FROM tensorflow/tensorflow:latest-gpu-py3-jupyter
 
 # File Author / Maintainer
 MAINTAINER Garrett Hoffman


### PR DESCRIPTION
`jupyter` could not be found within the container so I figured Tensorflow changed their images over time?
https://hub.docker.com/r/tensorflow/tensorflow states that one has to append `-jupyter` to get an image with jupyter included. The steps listed in the `README` now work again for me.